### PR TITLE
Add build command of module to load from browser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,4 +111,5 @@ typings/
 # next.js build output
 .next
 
-
+dist/*
+!dist/.gitkeep

--- a/README.md
+++ b/README.md
@@ -86,3 +86,13 @@ run below. then open `http://localhost:3333`
 export GEOMESH_GOOGLE_APIKEY=${google maps api key}
 npm run example
 ```
+
+## Use in browser
+
+execute the following command
+
+```sh
+npm run build
+```
+
+After that, read the file in the `dist/` directory from html

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "src/mesh.js",
   "scripts": {
     "test": "mocha test/test-mesh",
-    "example": "node example/server.js"
+    "example": "node example/server.js",
+    "build": "webpack --mode production"
   },
   "author": "nazomikan",
   "license": "Apache-2.0",
@@ -15,6 +16,8 @@
   },
   "devDependencies": {
     "mocha": "^5.0.0",
-    "pug": "^2.0.0-rc.4"
+    "pug": "^2.0.0-rc.4",
+    "webpack": "^4.5.0",
+    "webpack-cli": "^2.0.14"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  entry: `${__dirname}/src/mesh.js`,
+  output: {
+    path: `${__dirname}/dist`,
+    filename: 'geo_mesh.js',
+    library: 'GeoMesh',
+    libraryTarget: 'umd'
+  }
+}


### PR DESCRIPTION
Added command to generate files to read from browser.
It uses webpack-cli.

## command is...

```sh
npm run build
```

The file is created in the `dist/` directory.